### PR TITLE
fix: ensure jwt is not in deny list before further authentication

### DIFF
--- a/src/main/java/com/iemr/tm/utils/JwtUtil.java
+++ b/src/main/java/com/iemr/tm/utils/JwtUtil.java
@@ -1,15 +1,15 @@
 package com.iemr.tm.utils;
 
-import java.security.Key;
-import java.util.Date;
 import java.util.function.Function;
 
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
 @Component
@@ -18,33 +18,53 @@ public class JwtUtil {
 	@Value("${jwt.secret}")
 	private String SECRET_KEY;
 
-	private static final long EXPIRATION_TIME = 24L * 60 * 60 * 1000; // 1 day in milliseconds
+	@Autowired
+	private TokenDenylist tokenDenylist;
 
 	// Generate a key using the secret
-	private Key getSigningKey() {
+	private SecretKey getSigningKey() {
 		if (SECRET_KEY == null || SECRET_KEY.isEmpty()) {
 			throw new IllegalStateException("JWT secret key is not set in application.properties");
 		}
 		return Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
 	}
 
-	// Generate JWT Token
-	public String generateToken(String username, String userId) {
-		Date now = new Date();
-		Date expiryDate = new Date(now.getTime() + EXPIRATION_TIME);
-
-		// Include the userId in the JWT claims
-		return Jwts.builder().setSubject(username).claim("userId", userId) // Add userId as a claim
-				.setIssuedAt(now).setExpiration(expiryDate).signWith(getSigningKey(), SignatureAlgorithm.HS256)
-				.compact();
-	}
-
 	// Validate and parse JWT Token
 	public Claims validateToken(String token) {
 		try {
-			return Jwts.parser().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody();
+			Claims claims = Jwts.parser()
+				.verifyWith(getSigningKey())
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+				
+			String jti = claims.getId();
+			
+			// Check if token is denylisted (only if jti exists)
+			if (jti != null && tokenDenylist.isTokenDenylisted(jti)) {
+				return null;
+			}
+			
+			return claims;
 		} catch (Exception e) {
 			return null; // Handle token parsing/validation errors
+		}
+	}
+
+	// Invalidate a token by adding it to denylist
+	public void invalidateToken(String token) {
+		try {
+			Claims claims = extractAllClaims(token);
+			if (claims != null && claims.getId() != null) {
+				// Get remaining time until expiration
+				long expirationTime = claims.getExpiration().getTime() - System.currentTimeMillis();
+				if (expirationTime > 0) {
+					tokenDenylist.addTokenToDenylist(claims.getId(), expirationTime);
+				}
+			}
+		} catch (Exception e) {
+			// Log error but don't throw - token might be invalid already
+			throw new RuntimeException("Failed to invalidate token", e);
 		}
 	}
 
@@ -54,10 +74,14 @@ public class JwtUtil {
 
 	public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
 		final Claims claims = extractAllClaims(token);
-		return claimsResolver.apply(claims);
+		return claims != null ? claimsResolver.apply(claims) : null;
 	}
 
 	private Claims extractAllClaims(String token) {
-		return Jwts.parser().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody();
+		return Jwts.parser()
+			.verifyWith(getSigningKey())
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
 	}
 }

--- a/src/main/java/com/iemr/tm/utils/TokenDenylist.java
+++ b/src/main/java/com/iemr/tm/utils/TokenDenylist.java
@@ -1,0 +1,40 @@
+package com.iemr.tm.utils;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class TokenDenylist {
+    private static final String PREFIX = "denied_";
+    
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+    
+    public void addTokenToDenylist(String jti, Long expirationTime) {
+        if (jti != null && expirationTime != null && expirationTime > 0) {
+            try {
+                String key = PREFIX + jti;
+                redisTemplate.opsForValue().set(key, true);
+                redisTemplate.expire(key, expirationTime, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to add token to denylist", e);
+            }
+        }
+    }
+    
+    public boolean isTokenDenylisted(String jti) {
+        if (jti == null) {
+            return false;
+        }
+        try {
+            Object value = redisTemplate.opsForValue().get(PREFIX + jti);
+            return value != null;
+        } catch (Exception e) {
+            // If Redis is down, assume token is valid to prevent service disruption
+            return false;
+        }
+    }
+
+}


### PR DESCRIPTION
## 📋 Description

JIRA ID: AMM-1507

Check if jti is present in deny list before authenticating.
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for token revocation, allowing tokens to be invalidated and denied access if necessary.
  - Introduced token denylisting, enabling detection of revoked or invalidated tokens.

- **Bug Fixes**
  - Improved handling of invalid or expired tokens, ensuring null is returned on validation failure.

- **Refactor**
  - Updated JWT validation to use modern parsing methods.
  - Enhanced claim extraction for better null safety.

- **Chores**
  - Removed token generation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->