### PR TITLE
fix: resolve 5 bugs in scheduling, specialist, JWT, and config layers

### DIFF
--- a/src/main/java/com/iemr/tm/service/schedule/SchedulingServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/schedule/SchedulingServiceImpl.java
@@ -22,7 +22,9 @@
 package com.iemr.tm.service.schedule;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -37,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.iemr.tm.data.schedule.Slot;
 import com.iemr.tm.data.schedule.SpecialistAvailability;
@@ -91,8 +94,10 @@ public class SchedulingServiceImpl implements SchedulingService {
 		// A - Available doctor is on duty hours
 		// B - Booked slot for doctor
 		// C - Cancel appointment
-		Integer startslot = ((startTime.getHours() * 60) + (startTime.getMinutes())) / 5;
-		Integer endslot = ((endTime.getHours() * 60) + (endTime.getMinutes())) / 5;
+		LocalTime startLocal = startTime.toLocalDateTime().toLocalTime();
+		LocalTime endLocal = endTime.toLocalDateTime().toLocalTime();
+		Integer startslot = ((startLocal.getHour() * 60) + startLocal.getMinute()) / 5;
+		Integer endslot = ((endLocal.getHour() * 60) + endLocal.getMinute()) / 5;
 		
 		String currentstatus = slotdetail.substring(startslot, endslot);
 
@@ -130,6 +135,7 @@ public class SchedulingServiceImpl implements SchedulingService {
 	}
 
 	@Override
+	@Transactional(rollbackFor = TMException.class)
 	public SpecialistAvailabilityDetail markAvailability(SpecialistAvailabilityDetail specialistInput)
 			throws TMException {
 		
@@ -140,11 +146,12 @@ public class SchedulingServiceImpl implements SchedulingService {
 
 		logger.info("specialistInput result" + specialistInput.toString());
 		Date temp = specialistInput.getConfiguredFromDate();
-		final Date startDate = new Date(temp.getYear(), temp.getMonth(), temp.getDate());
-		
+		final Date startDate = Date.from(
+				LocalDate.ofInstant(temp.toInstant(), ZoneId.systemDefault()).atStartOfDay(ZoneId.systemDefault()).toInstant());
 
 		Date temp1 = specialistInput.getConfiguredToDate();
-		final Date endDate = new Date(temp1.getYear(), temp1.getMonth(), temp1.getDate());
+		final Date endDate = Date.from(
+				LocalDate.ofInstant(temp1.toInstant(), ZoneId.systemDefault()).atStartOfDay(ZoneId.systemDefault()).toInstant());
 		final String createdBy = specialistInput.getCreatedBy();
 		final Long userID = specialistInput.getUserID();
 
@@ -172,35 +179,28 @@ public class SchedulingServiceImpl implements SchedulingService {
 	
 
 		List<Integer> excludedays = specialistInput.getExcludeDays();
-		IntStream.rangeClosed(0, durationDays).forEach(e -> {
-
-			try {
-				Date i = new Date(startDate.getTime());
-				i.setDate(i.getDate() + e);
-				Integer day = i.getDay();
-				if (!(excludedays != null && excludedays.size() > 0 && excludedays.contains(day))) {
-					System.out.println(i);
-					SpecialistAvailability now = result.get(i);
-					if (now == null) {
-						now = new SpecialistAvailability();
-						now.setUserID(userID);
-						now.setConfiguredDate((Date) i.clone());
-						now.setTimeSlot(initializeString());
-						now.setCreatedBy(createdBy);
-					} else {
-						now.setModifiedBy(createdBy);
-					}
-					now.setTimeSlot(updateString(now.getTimeSlot(), startTime, endTime, 'A'));
-
-					output.add(now);
-					logger.info("printintg" + now.toString());
+		for (int e = 0; e <= durationDays; e++) {
+			Date i = new Date(startDate.getTime());
+			i.setDate(i.getDate() + e);
+			Integer day = i.getDay();
+			if (!(excludedays != null && excludedays.size() > 0 && excludedays.contains(day))) {
+				System.out.println(i);
+				SpecialistAvailability now = result.get(i);
+				if (now == null) {
+					now = new SpecialistAvailability();
+					now.setUserID(userID);
+					now.setConfiguredDate((Date) i.clone());
+					now.setTimeSlot(initializeString());
+					now.setCreatedBy(createdBy);
+				} else {
+					now.setModifiedBy(createdBy);
 				}
+				now.setTimeSlot(updateString(now.getTimeSlot(), startTime, endTime, 'A'));
 
-			} catch (TMException e1) {
-			
-				e1.printStackTrace();
+				output.add(now);
+				logger.info("printintg" + now.toString());
 			}
-		});
+		}
 		logger.info("output result" + output.toString());
 		specialistAvailabilityRepo.saveAll(output);
 		specialistInput = specialistAvailabilityDetailRepo.save(specialistInput);
@@ -214,7 +214,8 @@ public class SchedulingServiceImpl implements SchedulingService {
 			throws TMException {
 		
 		Date temp = specialistInput.getConfiguredFromDate();
-		Date startDate = new Date(temp.getYear(), temp.getMonth(), temp.getDate());
+		Date startDate = Date.from(
+				LocalDate.ofInstant(temp.toInstant(), ZoneId.systemDefault()).atStartOfDay(ZoneId.systemDefault()).toInstant());
 
 		Timestamp startTime = specialistInput.getConfiguredFromTime();
 		Timestamp endTime = specialistInput.getConfiguredToTime();
@@ -299,7 +300,8 @@ public class SchedulingServiceImpl implements SchedulingService {
 	public String bookSlot(SpecialistInput2 specialistInput, char status) throws TMException {
 		
 		Date temp = specialistInput.getDate();
-		Date startDate = new Date(temp.getYear(), temp.getMonth(), temp.getDate());
+		Date startDate = Date.from(
+				LocalDate.ofInstant(temp.toInstant(), ZoneId.systemDefault()).atStartOfDay(ZoneId.systemDefault()).toInstant());
 
 		SpecialistAvailability slotdetails = specialistAvailabilityRepo.findOneByConfiguredDateAndUserID(startDate,
 				specialistInput.getUserID());

--- a/src/main/java/com/iemr/tm/service/schedule/SchedulingServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/schedule/SchedulingServiceImpl.java
@@ -25,6 +25,7 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -98,7 +99,11 @@ public class SchedulingServiceImpl implements SchedulingService {
 		LocalTime endLocal = endTime.toLocalDateTime().toLocalTime();
 		Integer startslot = ((startLocal.getHour() * 60) + startLocal.getMinute()) / 5;
 		Integer endslot = ((endLocal.getHour() * 60) + endLocal.getMinute()) / 5;
-		
+
+		if (startslot < 0 || endslot > slotdetail.length() || startslot >= endslot)
+			throw new TMException("Invalid slot window: startslot " + startslot + " endslot " + endslot
+					+ " for slotdetail length " + slotdetail.length());
+
 		String currentstatus = slotdetail.substring(startslot, endslot);
 
 		StringBuilder slotfinal = new StringBuilder();
@@ -155,8 +160,9 @@ public class SchedulingServiceImpl implements SchedulingService {
 		final String createdBy = specialistInput.getCreatedBy();
 		final Long userID = specialistInput.getUserID();
 
-		Integer durationDays = (int) ((endDate.getTime() - startDate.getTime()) / 86400000);
-		
+		LocalDate startLocalDate = LocalDate.ofInstant(startDate.toInstant(), ZoneId.systemDefault());
+		LocalDate endLocalDate = LocalDate.ofInstant(endDate.toInstant(), ZoneId.systemDefault());
+		long durationDays = ChronoUnit.DAYS.between(startLocalDate, endLocalDate);
 
 		Timestamp startTime = specialistInput.getConfiguredFromTime();
 		Timestamp endTime = specialistInput.getConfiguredToTime();
@@ -179,9 +185,9 @@ public class SchedulingServiceImpl implements SchedulingService {
 	
 
 		List<Integer> excludedays = specialistInput.getExcludeDays();
-		for (int e = 0; e <= durationDays; e++) {
-			Date i = new Date(startDate.getTime());
-			i.setDate(i.getDate() + e);
+		for (long e = 0; e <= durationDays; e++) {
+			LocalDate d = startLocalDate.plusDays(e);
+			Date i = Date.from(d.atStartOfDay(ZoneId.systemDefault()).toInstant());
 			Integer day = i.getDay();
 			if (!(excludedays != null && excludedays.size() > 0 && excludedays.contains(day))) {
 				System.out.println(i);

--- a/src/main/java/com/iemr/tm/service/specialist/SpecialistServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/specialist/SpecialistServiceImpl.java
@@ -22,8 +22,11 @@
 package com.iemr.tm.service.specialist;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -35,6 +38,8 @@ import com.iemr.tm.utils.exception.TMException;
 
 @Service
 public class SpecialistServiceImpl implements SpecialistService {
+
+	final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
 
 	@Autowired
 	SpecializationRepo specializationRepo;
@@ -73,7 +78,10 @@ public class SpecialistServiceImpl implements SpecialistService {
 		List<Object[]> obj = specializationRepo.getAllSPecialistForProvider(providerservicemapID);
 		if (obj.size() > 0) {
 			for (Object[] action : obj) {
-				if (action.length < 7) continue;
+				if (action.length < 7) {
+				logger.warn("Skipping malformed specialist row: {}", Arrays.toString(action));
+				continue;
+			}
 				specialistList.add(new Specialist(null, ((Number) action[0]).longValue(), (String) action[1],
 						(String) action[2], (String) action[3], ((Number) action[6]).longValue(), null, null, null,
 						null, (String) action[4]));

--- a/src/main/java/com/iemr/tm/service/specialist/SpecialistServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/specialist/SpecialistServiceImpl.java
@@ -73,6 +73,7 @@ public class SpecialistServiceImpl implements SpecialistService {
 		List<Object[]> obj = specializationRepo.getAllSPecialistForProvider(providerservicemapID);
 		if (obj.size() > 0) {
 			for (Object[] action : obj) {
+				if (action.length < 7) continue;
 				specialistList.add(new Specialist(null, ((Number) action[0]).longValue(), (String) action[1],
 						(String) action[2], (String) action[3], ((Number) action[6]).longValue(), null, null, null,
 						null, (String) action[4]));

--- a/src/main/java/com/iemr/tm/utils/JwtUtil.java
+++ b/src/main/java/com/iemr/tm/utils/JwtUtil.java
@@ -63,8 +63,7 @@ public class JwtUtil {
 				}
 			}
 		} catch (Exception e) {
-			// Log error but don't throw - token might be invalid already
-			throw new RuntimeException("Failed to invalidate token", e);
+			// Token is already expired or invalid — nothing to denylist, treat as success
 		}
 	}
 

--- a/src/main/java/com/iemr/tm/utils/config/ConfigProperties.java
+++ b/src/main/java/com/iemr/tm/utils/config/ConfigProperties.java
@@ -99,7 +99,7 @@ public class ConfigProperties {
 
 	public static boolean getExtendExpiryTime() {
 		if (extendExpiryTime == null) {
-			extendExpiryTime = getBoolean("iemr.session.expiry.time");
+			extendExpiryTime = getBoolean("iemr.extend.expiry.time");
 		}
 		return extendExpiryTime;
 	}


### PR DESCRIPTION
## Summary

- Fixed silently swallowed `TMException` in `SchedulingServiceImpl` — replaced `IntStream.forEach` lambda with a plain `for` loop so exceptions propagate; added `@Transactional(rollbackFor = TMException.class)` for atomicity
- Fixed timezone-sensitive deprecated `Date` APIs — replaced `Timestamp.getHours()`/`getMinutes()` with `toLocalDateTime().toLocalTime()` and deprecated `new Date(year, month, date)` constructors with `LocalDate.ofInstant(..., ZoneId.systemDefault())`
- Fixed `ArrayIndexOutOfBoundsException` risk in `SpecialistServiceImpl.getAllSpecialist` — added bounds guard before accessing `action[6]`
- Fixed HTTP 500 on logout with expired token in `JwtUtil.invalidateToken` — removed erroneous `RuntimeException` rethrow in catch block
- Fixed wrong property key in `ConfigProperties.getExtendExpiryTime` — changed from `"iemr.session.expiry.time"` (integer) to `"iemr.extend.expiry.time"` (boolean) so session extension config is read correctly

## Test plan

- [ ] `markAvailability` with a date range: verify `TMException` on a conflict rolls back all inserts
- [ ] Scheduling on a non-UTC server: verify slot indices are correct
- [ ] `getAllSpecialist` returns results without `ArrayIndexOutOfBoundsException`
- [ ] Logout with an expired JWT returns HTTP 200, not 500
- [ ] Setting `iemr.extend.expiry.time=true` causes `getExtendExpiryTime()` to return `true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration property for session extension.
  * Added validation to skip malformed specialist records without crashing.
  * Made token invalidation gracefully handle expired/invalid tokens.

* **Refactor**
  * Switched scheduling logic to timezone-aware date/time handling.
  * Improved availability handling with normalized start-of-day dates and stronger transactional behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/Scheduler-API/pull/69)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->